### PR TITLE
Don't hardcode dark mode

### DIFF
--- a/AnkiFields/styling.css
+++ b/AnkiFields/styling.css
@@ -2,8 +2,6 @@
     font-family: "MS UI Gothic", "Noto Sans CJK JP", "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, メイリオ, Meiryo, "ＭＳ Ｐゴシック", "MS PGothic", "ＭＳ ゴシック", "MS Gothic", TakaoPGothic, sans-serif;
     font-size: calc(1em + 2vmax);
     text-align: center;
-    color: white;
-    background-color: #222222;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
Anki already has a dark mode. If users want to use light mode, the hardcoded dark mode takes precedence, meaning it will still be dark, forcing users to delete these lines if they want to use Anki in light mode.

Because Anki already has a dark mode anyway, these styles are unnecessary.